### PR TITLE
feat: integrate complete Hero CRUD flow via RabbitMQ (ms-agent ↔ ms-marvel)

### DIFF
--- a/src/main/java/com/com/github/lucasbandeira/msagent/confg/MQConfig.java
+++ b/src/main/java/com/com/github/lucasbandeira/msagent/confg/MQConfig.java
@@ -9,10 +9,16 @@ import org.springframework.stereotype.Component;
 public class MQConfig {
 
     @Value("${mq.queues.hero-registration}")
-    private String queueName;
+    private String registrationQueue;
+
+    @Value("${mq.queues.hero-update}")
+    private String updateQueue;
 
     @Bean
     public Queue heroRegistrationQueue(){
-        return new Queue(queueName,true);
+        return new Queue(registrationQueue,true);
     }
+
+    @Bean
+    public Queue heroUpdateQueue(){return new Queue(updateQueue,true);}
 }

--- a/src/main/java/com/com/github/lucasbandeira/msagent/controller/AgentHeroController.java
+++ b/src/main/java/com/com/github/lucasbandeira/msagent/controller/AgentHeroController.java
@@ -11,6 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/agent/hero")
@@ -24,6 +27,16 @@ public class AgentHeroController {
         return ResponseEntity.status(HttpStatus.OK).body(hero);
     }
 
+    @GetMapping("/by-agent/{agentCode}")
+    public ResponseEntity<List<HeroResponseDTO>> getHeroesByAgent(@PathVariable String agentCode){
+        return ResponseEntity.status(HttpStatus.OK).body(heroService.getHeroesByAgent(agentCode));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<HeroResponseDTO>>getAllHeroes(){
+        return ResponseEntity.status(HttpStatus.OK).body(heroService.findAll());
+    }
+
     @PostMapping("/register-hero")
     public ResponseEntity registerHero(@RequestBody HeroAgentRequestDTO heroAgentRequestDTO){
         try{
@@ -32,5 +45,21 @@ public class AgentHeroController {
         }catch (HeroRegistrationException e){
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
+    }
+
+    @PutMapping("/{heroCode}")
+    public ResponseEntity updateHero(@PathVariable String heroCode, @RequestBody HeroRequestDTO heroRequestDTO){
+        try{
+        HeroRegistrationProtocol heroRegistrationProtocol = heroService.updateHero(heroCode,heroRequestDTO);
+            return ResponseEntity.status(HttpStatus.OK).body(heroRegistrationProtocol);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void>deleteHero( @PathVariable UUID id ){
+        heroService.deleteHero(id);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/com/github/lucasbandeira/msagent/infra/clients/HeroesResourceClient.java
+++ b/src/main/java/com/com/github/lucasbandeira/msagent/infra/clients/HeroesResourceClient.java
@@ -3,16 +3,30 @@ package com.com.github.lucasbandeira.msagent.infra.clients;
 import com.com.github.lucasbandeira.msagent.model.dto.HeroResponseDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-    @FeignClient(value = "msmarvel",path = "/hero")
-    public interface HeroesResourceClient {
+import java.util.List;
+import java.util.UUID;
 
-        @GetMapping("/status")
-        String status();
+@FeignClient(value = "msmarvel", path = "/hero")
+public interface HeroesResourceClient {
 
-        @GetMapping(params = "hero-code")
-        ResponseEntity<HeroResponseDTO> getHeroByCode( @RequestParam("hero-code")String heroCode);
+    @GetMapping("/status")
+    String status();
 
-    }
+    @GetMapping(params = "hero-code")
+    ResponseEntity <HeroResponseDTO> getHeroByCode( @RequestParam("hero-code") String heroCode );
+
+    @GetMapping
+    ResponseEntity <List <HeroResponseDTO>> findAll();
+
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void>deleteHero(@PathVariable UUID id);
+
+    @GetMapping("/by-agent/{agentCode}")
+    ResponseEntity<List<HeroResponseDTO>> getHeroesByAgent(@PathVariable String agentCode);
+
+}

--- a/src/main/java/com/com/github/lucasbandeira/msagent/infra/mqueue/RequestHeroPublisher.java
+++ b/src/main/java/com/com/github/lucasbandeira/msagent/infra/mqueue/RequestHeroPublisher.java
@@ -1,5 +1,6 @@
 package com.com.github.lucasbandeira.msagent.infra.mqueue;
 
+import com.com.github.lucasbandeira.msagent.model.dto.AgentRequestDTO;
 import com.com.github.lucasbandeira.msagent.model.dto.HeroAgentRequestDTO;
 import com.com.github.lucasbandeira.msagent.model.dto.HeroRequestDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -11,15 +12,23 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RequestHeroRegistrationPublisher {
+public class RequestHeroPublisher {
 
     private final RabbitTemplate rabbitTemplate;
     private final Queue heroRegistrationQueue;
+    private final Queue heroUpdateQueue;
 
-    public void RegisterHero( HeroAgentRequestDTO heroAgentRequestDTO )throws JsonProcessingException{
+    public void sendMessage( HeroAgentRequestDTO heroAgentRequestDTO )throws JsonProcessingException{
         var json = convertIntoJson(heroAgentRequestDTO);
         rabbitTemplate.convertAndSend(heroRegistrationQueue.getName(),json);
     }
+
+    public void updateHero( HeroRequestDTO heroRequestDTO ) throws JsonProcessingException {
+        var json = convertHeroIntoJson(heroRequestDTO);
+        rabbitTemplate.convertAndSend(heroUpdateQueue.getName(),json);
+    }
+
+
 
     private String convertIntoJson(HeroAgentRequestDTO heroAgentRequestDTO) throws JsonProcessingException {
 
@@ -28,4 +37,12 @@ public class RequestHeroRegistrationPublisher {
         return json;
 
     }
+    private String convertHeroIntoJson(HeroRequestDTO heroRequestDTO) throws JsonProcessingException {
+
+        ObjectMapper mapper = new ObjectMapper();
+        var json = mapper.writeValueAsString(heroRequestDTO);
+        return json;
+    }
+
+
 }

--- a/src/main/java/com/com/github/lucasbandeira/msagent/model/Agent.java
+++ b/src/main/java/com/com/github/lucasbandeira/msagent/model/Agent.java
@@ -30,6 +30,6 @@ public class Agent {
     }
 
     public static Agent fromDto( AgentRequestDTO agentRequestDto ) {
-        return new Agent(agentRequestDto.agentCode(), agentRequestDto.name(), agentRequestDto.active());
+        return new Agent(agentRequestDto.agentCode(), agentRequestDto.name(), true);
     }
 }

--- a/src/main/java/com/com/github/lucasbandeira/msagent/model/dto/AgentRequestDTO.java
+++ b/src/main/java/com/com/github/lucasbandeira/msagent/model/dto/AgentRequestDTO.java
@@ -11,7 +11,5 @@ public record AgentRequestDTO(
         @Column(unique = true)
         String agentCode,
         @NotBlank(message = "The name must not be null or blank!")
-        String name,
-        @NotNull(message = "The 'active' Field must not be null")
-        boolean active) {
+        String name) {
 }

--- a/src/main/java/com/com/github/lucasbandeira/msagent/service/HeroService.java
+++ b/src/main/java/com/com/github/lucasbandeira/msagent/service/HeroService.java
@@ -2,15 +2,17 @@ package com.com.github.lucasbandeira.msagent.service;
 
 import com.com.github.lucasbandeira.msagent.exception.HeroNotFoundException;
 import com.com.github.lucasbandeira.msagent.infra.clients.HeroesResourceClient;
-import com.com.github.lucasbandeira.msagent.infra.mqueue.RequestHeroRegistrationPublisher;
+import com.com.github.lucasbandeira.msagent.infra.mqueue.RequestHeroPublisher;
 import com.com.github.lucasbandeira.msagent.model.HeroRegistrationProtocol;
 import com.com.github.lucasbandeira.msagent.model.dto.HeroAgentRequestDTO;
 import com.com.github.lucasbandeira.msagent.model.dto.HeroRequestDTO;
 import com.com.github.lucasbandeira.msagent.model.dto.HeroResponseDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -18,11 +20,10 @@ import java.util.UUID;
 public class HeroService {
 
     private final HeroesResourceClient heroesResourceClient;
-    private final RequestHeroRegistrationPublisher heroRegistrationPublisher;
+    private final RequestHeroPublisher heroRegistrationPublisher;
 
 
     public HeroResponseDTO getHeroStatus( String heroCode){
-
         try{
             return heroesResourceClient.getHeroByCode(heroCode).getBody();
         }
@@ -33,11 +34,39 @@ public class HeroService {
 
     public HeroRegistrationProtocol registerHero( HeroAgentRequestDTO heroAgentRequestDTO ){
         try{
-            heroRegistrationPublisher.RegisterHero(heroAgentRequestDTO);
+            heroRegistrationPublisher.sendMessage(heroAgentRequestDTO);
             var protocol = UUID.randomUUID().toString();
             return new HeroRegistrationProtocol(protocol);
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public HeroRegistrationProtocol updateHero(String heroCode, HeroRequestDTO heroRequestDTO){
+        try {
+            heroRegistrationPublisher.updateHero(heroRequestDTO);
+            var protocol = UUID.randomUUID().toString();
+            return new HeroRegistrationProtocol(protocol);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public List<HeroResponseDTO>getHeroesByAgent(String agentCode){
+        return heroesResourceClient.getHeroesByAgent(agentCode).getBody();
+    }
+
+    public List<HeroResponseDTO> findAll(){
+        return heroesResourceClient.findAll().getBody();
+    }
+
+    public void deleteHero(UUID id){
+        try{
+            heroesResourceClient.deleteHero(id).getBody();
+
+        } catch (FeignException.NotFound e) {
+            throw new HeroNotFoundException("Hero not found. Deletion cannot be completed");
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,4 @@ eureka:
 mq:
   queues:
     hero-registration: hero-registration
+    hero-update: hero-update


### PR DESCRIPTION
This PR implements full communication between the ms-agent and ms-marvel microservices using RabbitMQ, following an event-driven architecture to support Hero CRUD operations.

Implemented Features:
✅ Register a new hero associated with an agent.

🔄 Update an existing hero’s information.

🔍 Retrieve all registered heroes.

📋 List all heroes registered by a specific agent.

❌ Delete a hero by ID.

Notes:
- Uses the HeroAgentRequestDTO to send complete data across services.

- The ms-agent service publishes messages to RabbitMQ encapsulating CRUD actions.

- The ms-marvel service consumes messages, executing persistence and business logic accordingly.

- Agent existence is validated by code to prevent duplication.

- The active field is used for internal validation but is excluded from response bodies for security reasons.